### PR TITLE
feat!: multifix

### DIFF
--- a/openapi3.json
+++ b/openapi3.json
@@ -93,17 +93,34 @@
           },
           "paysProduction": {
             "title": "Pays de production",
-            "$ref": "#/components/schemas/Pays"
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Pays"
+            }
           },
           "statut": {
             "title": "Statut du test",
-            "$ref": "#/components/schemas/Statut"
+            "$ref": "#/components/schemas/ValidationStatus"
+          },
+          "validation_CE": {
+            "title": "Statut validation CE",
+            "$ref": "#/components/schemas/ValidationStatus"
+          },
+          "validation_International": {
+            "title": "Statut validation International",
+            "$ref": "#/components/schemas/ValidationStatus"
+          },
+          "validation_CNR": {
+            "title": "Statut validation CNR",
+            "$ref": "#/components/schemas/ValidationStatusCNR"
+          },
+          "validation_ANSM": {
+            "title": "Statut validation ANSM",
+            "$ref": "#/components/schemas/ValidationStatus"
           },
           "distributeur": {
             "$ref": "#/components/schemas/Distributeur"
-          },
-          "normes": {
-            "$ref": "#/components/schemas/Normes"
           },
           "natureProduit": {
             "$ref": "#/components/schemas/NatureProduit"
@@ -117,7 +134,7 @@
           "typeCible": {
             "$ref": "#/components/schemas/TypeCible"
           },
-          "nombresCibles": {
+          "nombreCibles": {
             "$ref": "#/components/schemas/NombreCibles"
           },
           "machinesNecessaires": {
@@ -130,6 +147,13 @@
           "courbeCinetiquePositive": {
             "title": "Courbe type de cinétique de positivité du test",
             "type": "string"
+          },
+          "courbeCinetiquePositiveDocs": {
+            "title": "Documents relatifs à la courbe type de cinétique de positivité du test",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/File"
+            }
           },
           "typePrelevement": {
             "title": "Type de prélèvement nécessaire au test",
@@ -155,11 +179,11 @@
           },
           "valeurPredictivePositive": {
             "title": "Valeur Prédictive positive",
-            "type": "integer"
+            "type": "string"
           },
           "valeurPredictiveNegative": {
             "title": "Valeur Prédictive négative",
-            "type": "integer"
+            "type": "string"
           },
           "sensibilite": {
             "title": "Sensibilité clinique déclarée par le fabricant",
@@ -202,7 +226,7 @@
           },
           "capaciteProductionHebdomadaire": {
             "title": "Capacité de production par semaine",
-            "type": "string"
+            "type": "integer"
           },
           "usagesTest": {
             "title": "Usages du test",
@@ -245,25 +269,6 @@
           }
         }
       },
-      "ValidationStatusCNR": {
-        "title": "Status",
-        "type": "string",
-        "enum": [
-          "Validé",
-          "En cours d’évaluation",
-          "En cours d’expédition",
-          "Non initié",
-          "Refusé"
-        ]
-      },
-      "ValidationStatus": {
-        "title": "Status",
-        "type": "string",
-        "enum": [
-          "Validé",
-          "Non validé"
-        ]
-      },
       "Pays": {
         "description": "Pays à la norme ISO3361-alpha2",
         "example": "FR",
@@ -281,32 +286,6 @@
           "nationalite": {
             "title": "Nationalité du distributeur",
             "$ref": "#/components/schemas/Pays"
-          }
-        }
-      },
-      "Normes": {
-        "title": "Type de validation",
-        "type": "object",
-        "properties": {
-          "CE": {
-            "title": "CE",
-            "$ref": "#/components/schemas/ValidationStatus"
-          },
-          "International": {
-            "title": "International",
-            "$ref": "#/components/schemas/ValidationStatus"
-          },
-          "CNR": {
-            "title": "CNR",
-            "$ref": "#/components/schemas/ValidationStatusCNR"
-          },
-          "ANSM": {
-            "title": "ANSM",
-            "$ref": "#/components/schemas/ValidationStatus"
-          },
-          "Inconnue": {
-            "title": "Inconnue",
-            "$ref": "#/components/schemas/ValidationStatus"
           }
         }
       },
@@ -339,7 +318,7 @@
       "TypeCible": {
         "enum": [
           "Anticorps",
-          "ARN Viral"
+          "ARN Viral / Antigènes"
         ],
         "title": "Type de cible",
         "type": "string"
@@ -455,12 +434,23 @@
           "Autre"
         ]
       },
-      "Statut": {
+      "ValidationStatus": {
         "type": "string",
         "enum": [
-          "Non validé",
-          "En cours d’évaluation",
+          "Écarté",
+          "A l’étude",
           "Validé",
+          "Inconnu"
+        ]
+      },
+      "ValidationStatusCNR": {
+        "type": "string",
+        "enum": [
+          "Validé",
+          "En cours d’évaluation",
+          "En cours d’expédition",
+          "Non initié",
+          "Refusé",
           "Inconnu"
         ]
       },

--- a/openapi3.json
+++ b/openapi3.json
@@ -92,12 +92,7 @@
             ]
           },
           "paysProduction": {
-            "title": "Pays de production",
-            "uniqueItems": true,
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Pays"
-            }
+            "$ref": "#/components/schemas/PaysProduction"
           },
           "statut": {
             "title": "Statut du test",
@@ -269,6 +264,30 @@
           }
         }
       },
+      "PaysProduction": {
+        "title": "Pays de production",
+        "type": "object",
+        "properties": {
+          "pays1": {
+            "title": "Pays 1",
+            "items": {
+              "$ref": "#/components/schemas/Pays"
+            }
+          },
+          "pays2": {
+            "title": "Pays 2",
+            "items": {
+              "$ref": "#/components/schemas/Pays"
+            }
+          },
+          "pays3": {
+            "title": "Pays 3",
+            "items": {
+              "$ref": "#/components/schemas/Pays"
+            }
+          }
+        }
+      },
       "Pays": {
         "description": "Pays à la norme ISO3361-alpha2",
         "example": "FR",
@@ -330,7 +349,7 @@
           "> 2"
         ],
         "title": "Nombre de cibles",
-        "type": "integer"
+        "type": "string"
       },
       "OuvertureTest": {
         "title": "Test ouvert / fermé",

--- a/openapi3.yaml
+++ b/openapi3.yaml
@@ -169,7 +169,7 @@ components:
           "$ref": "#/components/schemas/DisponibiliteNationale"
         capaciteProductionHebdomadaire:
           title: Capacité de production par semaine
-          type: string
+          type: integer
         usagesTest:
           title: Usages du test
           uniqueItems: true

--- a/openapi3.yaml
+++ b/openapi3.yaml
@@ -88,8 +88,6 @@ components:
           "$ref": "#/components/schemas/ValidationStatus"
         distributeur:
           "$ref": "#/components/schemas/Distributeur"
-        normes:
-          "$ref": "#/components/schemas/Normes"
         natureProduit:
           "$ref": "#/components/schemas/NatureProduit"
         technologie:

--- a/openapi3.yaml
+++ b/openapi3.yaml
@@ -66,11 +66,7 @@ components:
             - THOMSON
             - AKAI
         paysProduction:
-          title: Pays de production
-          uniqueItems: true
-          type: array
-          items:
-            "$ref": "#/components/schemas/Pays"
+          "$ref": "#/components/schemas/PaysProduction"
         statut:
           title: Statut du test
           "$ref": "#/components/schemas/ValidationStatus"
@@ -197,6 +193,22 @@ components:
           type: array
           items:
             "$ref": "#/components/schemas/File"
+    PaysProduction:
+      title: Pays de production
+      type: object
+      properties:
+        pays1:
+          title: Pays 1
+          items:
+            "$ref": "#/components/schemas/Pays"
+        pays2:
+          title: Pays 2
+          items:
+            "$ref": "#/components/schemas/Pays"
+        pays3:
+          title: Pays 3
+          items:
+            "$ref": "#/components/schemas/Pays"
     Pays:
       description: Pays à la norme ISO3361-alpha2
       example: FR
@@ -244,7 +256,7 @@ components:
         - 2
         - "> 2"
       title: Nombre de cibles
-      type: integer
+      type: string
     OuvertureTest:
       title: Test ouvert / fermé
       enum:

--- a/openapi3.yaml
+++ b/openapi3.yaml
@@ -130,13 +130,11 @@ components:
           minimum: 0
           maximum: 1000000
         valeurPredictivePositive:
-          # type de donnée ?
           title: Valeur Prédictive positive
-          type: number
+          type: string
         valeurPredictiveNegative:
-          # type de donnée ?
           title: Valeur Prédictive négative
-          type: number
+          type: string
         sensibilite:
           title: Sensibilité clinique déclarée par le fabricant
           type: string

--- a/openapi3.yaml
+++ b/openapi3.yaml
@@ -96,7 +96,7 @@ components:
           "$ref": "#/components/schemas/TypeReactif"
         typeCible:
           "$ref": "#/components/schemas/TypeCible"
-        nombresCibles:
+        nombreCibles:
           "$ref": "#/components/schemas/NombreCibles"
         machinesNecessaires:
           title: Automates compatibles

--- a/openapi3.yaml
+++ b/openapi3.yaml
@@ -132,11 +132,11 @@ components:
         valeurPredictivePositive:
           # type de donnée ?
           title: Valeur Prédictive positive
-          type: integer
+          type: number
         valeurPredictiveNegative:
           # type de donnée ?
           title: Valeur Prédictive négative
-          type: integer
+          type: number
         sensibilite:
           title: Sensibilité clinique déclarée par le fabricant
           type: string

--- a/openapi3.yaml
+++ b/openapi3.yaml
@@ -67,10 +67,25 @@ components:
             - AKAI
         paysProduction:
           title: Pays de production
-          "$ref": "#/components/schemas/Pays"
+          uniqueItems: true
+          type: array
+          items:
+            "$ref": "#/components/schemas/Pays"
         statut:
           title: Statut du test
-          "$ref": "#/components/schemas/Statut"
+          "$ref": "#/components/schemas/ValidationStatus"
+        validation_CE:
+          title: Statut validation CE
+          "$ref": "#/components/schemas/ValidationStatus"
+        validation_International:
+          title: Statut validation International
+          "$ref": "#/components/schemas/ValidationStatus"
+        validation_CNR:
+          title: Statut validation CNR
+          "$ref": "#/components/schemas/ValidationStatusCNR"
+        validation_ANSM:
+          title: Statut validation ANSM
+          "$ref": "#/components/schemas/ValidationStatus"
         distributeur:
           "$ref": "#/components/schemas/Distributeur"
         normes:
@@ -94,6 +109,11 @@ components:
           # type de donnée ?
           title: Courbe type de cinétique de positivité du test
           type: string
+        courbeCinetiquePositiveDocs:
+          title: "Documents relatifs à la courbe type de cinétique de positivité du test"
+          type: array
+          items:
+            "$ref": "#/components/schemas/File"
         typePrelevement:
           title: Type de prélèvement nécessaire au test
           uniqueItems: true
@@ -181,23 +201,6 @@ components:
           type: array
           items:
             "$ref": "#/components/schemas/File"
-
-    # Champs utilisés
-    ValidationStatusCNR:
-      title: Status
-      type: string
-      enum:
-        - Validé
-        - En cours d’évaluation
-        - En cours d’expédition
-        - Non initié
-        - Refusé
-    ValidationStatus:
-      title: Status
-      type: string
-      enum:
-        - Validé
-        - Non validé
     Pays:
       description: Pays à la norme ISO3361-alpha2
       example: FR
@@ -213,25 +216,6 @@ components:
           nationalite:
             title: Nationalité du distributeur
             "$ref": "#/components/schemas/Pays"
-    Normes:
-      title: Type de validation
-      type: object
-      properties:
-        CE:
-          title: CE
-          "$ref": "#/components/schemas/ValidationStatus"
-        International:
-          title: International
-          "$ref": "#/components/schemas/ValidationStatus"
-        CNR:
-          title: CNR
-          "$ref": "#/components/schemas/ValidationStatusCNR"
-        ANSM:
-          title: ANSM
-          "$ref": "#/components/schemas/ValidationStatus"
-        Inconnue:
-          title: Inconnue
-          "$ref": "#/components/schemas/ValidationStatus"
     NatureProduit:
       enum:
         - Réactif
@@ -255,7 +239,7 @@ components:
     TypeCible:
       enum:
         - Anticorps
-        - ARN Viral
+        - ARN Viral / Antigènes
       title: Type de cible
       type: string
     NombreCibles:
@@ -348,12 +332,21 @@ components:
         - Laboratoires de ville
         - Pharmacies
         - Autre
-    Statut:
+    ValidationStatus:
       type: string
       enum:
-        - Non validé
-        - En cours d’évaluation
+        - Écarté
+        - A l’étude
         - Validé
+        - Inconnu
+    ValidationStatusCNR:
+      type: string
+      enum:
+        - Validé
+        - En cours d’évaluation
+        - En cours d’expédition
+        - Non initié
+        - Refusé
         - Inconnu
     StatutRemboursement:
       type: string


### PR DESCRIPTION
Breaking changes :

 - `paysProduction` is now an object with `{pays1, pays2, pays3}`
 - `normes` is replaced by `validation_CE`, `validation_International`, `validation_CNR`, `validation_ANSM`
 - `nombreCibles` is a string
 - `valeurPredictivePositive` and `valeurPredictiveNegative` are a string
 - `capaciteProductionHebdomadaire` is integer
 - added `courbeCinetiquePositiveDocs` array of files